### PR TITLE
RDM-1937 mandatory fields preventing to move forward

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:coverage": "istanbul check-coverage --statements 80 --lines 80 --functions 80 --branches 80",
     "test:a11y": "echo 'TODO: Accessibility tests'",
     "test:nsp": "nsp check",
-    "test:smoke": "sh ./runSmokeTests.sh",
+    "test:smoke": "cd test && docker build -t ccd-protractor:latest . && docker run -it --rm -e CCD_CASEWORKER_AUTOTEST_EMAIL=$CCD_CASEWORKER_AUTOTEST_EMAIL -e CCD_CASEWORKER_AUTOTEST_PASSWORD=$CCD_CASEWORKER_AUTOTEST_PASSWORD -e TEST_FRONTEND_URL=$TEST_FRONTEND_URL --name protractor-runner -v $(PWD):/protractor/project ccd-protractor:latest test:smokeDocker && cd ..",
     "test:smokeDocker": "protractor test/smoke.conf.js",
     "test:functional": "echo 'TODO: Functional tests'",
     "lint": "tslint --project . -t verbose 'src/**/*.ts'",

--- a/src/app/shared/palette/address/write-address-field.component.ts
+++ b/src/app/shared/palette/address/write-address-field.component.ts
@@ -72,7 +72,10 @@ export class WriteAddressFieldComponent extends AbstractFieldWriteComponent impl
   }
 
   isAddressSet() {
-    const address = this.caseField.value;
+    if (!this.writeComplexFieldComponent || !this.writeComplexFieldComponent.complexGroup) {
+      return false;
+    }
+    const address = this.writeComplexFieldComponent.complexGroup.value;
     let hasAddress = false;
     if (address) {
       Object.keys(address).forEach(function (key) {

--- a/src/app/shared/palette/address/write-address-field.html
+++ b/src/app/shared/palette/address/write-address-field.html
@@ -26,7 +26,7 @@
   <span class="manual-link" *ngIf="!isAddressSet()" (click)="blankAddress()">I can't enter a UK postcode</span>
 
   <ccd-write-complex-type-field
-    [hidden]="!caseField.value"
+    [hidden]="!isAddressSet()"
     [(caseField)]="caseField"
     [renderLabel]="false"
     [registerControl]="registerControl"

--- a/src/app/shared/palette/complex/write-complex-field.component.ts
+++ b/src/app/shared/palette/complex/write-complex-field.component.ts
@@ -29,7 +29,7 @@ export class WriteComplexFieldComponent extends AbstractFieldWriteComponent impl
 
   buildControlRegistrer(caseField: CaseField): (control: FormControl) => AbstractControl {
     return control => {
-      if (this.complexGroup.contains(caseField.id)) {
+      if (this.complexGroup.get(caseField.id)) {
         return this.complexGroup.get(caseField.id);
       }
       if (!this.ignoreMandatory) {


### PR DESCRIPTION
fix for RDM-1937 mandatory fields preventing to move forward The case appeared as
user fills in the values of a complex field which has conditional hide/show and moves next page, then user clicks previous, changes a field value that affects conditional hide/show expression
and that results in displaying a mandatory field which wasn't displayed before
then this mandatory field's value is not validated properly and so moving forward is prevented.

https://tools.hmcts.net/jira/browse/RDM-1937

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```