### PR TITLE
Config: Compute default gateway URL

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -4,6 +4,9 @@ provider "vault" {
 
 locals {
   env_ase_url = "${var.env}.service.${data.terraform_remote_state.core_apps_compute.ase_name[0]}.internal"
+
+  default_ccd_gateway_url = "https://ccd-api-gateway-web-${local.env_ase_url}"
+  ccd_gateway_url = "${var.ccd_gateway_url != "" ? var.ccd_gateway_url : local.default_ccd_gateway_url}"
 }
 
 module "case-management-web" {
@@ -18,17 +21,17 @@ module "case-management-web" {
 
   app_settings = {
     IDAM_LOGIN_URL = "${var.idam_authentication_web_url}/login"
-    CCD_GW_LOGOUT_URL = "${var.ccd_gateway_url}/logout"
-    CCD_API_URL = "${var.ccd_gateway_url}/aggregated"
-    CCD_DATA_URL = "${var.ccd_gateway_url}/data"
+    CCD_GW_LOGOUT_URL = "${local.ccd_gateway_url}/logout"
+    CCD_API_URL = "${local.ccd_gateway_url}/aggregated"
+    CCD_DATA_URL = "${local.ccd_gateway_url}/data"
     CCD_ACTIVITY_URL = "" // Activity disabled until it's deployed on CNP
-    CCD_GW_OAUTH2_URL = "${var.ccd_gateway_url}/oauth2"
+    CCD_GW_OAUTH2_URL = "${local.ccd_gateway_url}/oauth2"
     CCD_GW_OAUTH2_CLIENT_ID = "ccd_gateway"
-    DM_URL = "${var.ccd_gateway_url}/documents"
+    DM_URL = "${local.ccd_gateway_url}/documents"
     DM_URL_REMOTE = "${var.document_management_url}/documents"
     CCD_PAGE_SIZE = 25
-    POSTCODE_LOOKUP_URL = "${var.ccd_gateway_url}/addresses?postcode=$${postcode}"
-    PRINT_SERVICE_URL = "${var.ccd_gateway_url}/print"
+    POSTCODE_LOOKUP_URL = "${local.ccd_gateway_url}/addresses?postcode=$${postcode}"
+    PRINT_SERVICE_URL = "${local.ccd_gateway_url}/print"
     PRINT_SERVICE_URL_REMOTE = "${var.ccd_print_service_url}"
     WEBSITE_NODE_DEFAULT_VERSION = "8.9.4"
   }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -33,7 +33,7 @@ variable "idam_authentication_web_url" {
 }
 
 variable "ccd_gateway_url" {
-  default = "https://gateway-ccd.nonprod.platform.hmcts.net"
+  type = "string"
 }
 
 variable "document_management_url" {
@@ -47,4 +47,3 @@ variable "ccd_print_service_url" {
 variable "external_host_name" {
   default = "ccd-case-management-web.nonprod.platform.hmcts.net"
 }
-


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Gateway URL default is not compatible with Sandbox envs.
For envs that have a proper hostnames registered, this hostnames should be picked from relevant `.tfvars`.
For envs that don't, like `sandbox`, the gateway URL should be computed from the ASE.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
