### PR TITLE
Accept optional port in document URL

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,4 +1,4 @@
 idam_authentication_web_url = "https://idam.preprod.ccidam.reform.hmcts.net"
 ccd_gateway_url = "https://gateway-ccd.nonprod.platform.hmcts.net"
-document_management_url = "^https?://(?:api-gateway\\.preprod\\.dm\\.reform\\.hmcts\\.net|dm-store-aat\\.service\\.core-compute-aat\\.internal)"
+document_management_url = "^https?://(?:api-gateway\\.preprod\\.dm\\.reform\\.hmcts\\.net|dm-store-aat\\.service\\.core-compute-aat\\.internal(?::\\d+)?)"
 ccd_print_service_url = "https://return-case-doc-ccd.nonprod.platform.hmcts.net"

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -1,4 +1,4 @@
 idam_authentication_web_url = "https://idam.preprod.ccidam.reform.hmcts.net"
 ccd_gateway_url = "https://gateway.ccd.demo.platform.hmcts.net"
-document_management_url = "^https?://(?:api-gateway\\.preprod\\.dm\\.reform\\.hmcts\\.net|dm-store-demo\\.service\\.core-compute-demo\\.internal)"
+document_management_url = "^https?://(?:api-gateway\\.preprod\\.dm\\.reform\\.hmcts\\.net|dm-store-demo\\.service\\.core-compute-demo\\.internal(?::\\d+)?)"
 ccd_print_service_url = "https://return-case-doc.ccd.demo.platform.hmcts.net"

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,4 +1,4 @@
 idam_authentication_web_url = "https://www.idam.reform.hmcts.net"
 ccd_gateway_url = "https://gateway.ccd.platform.hmcts.net"
-document_management_url = "^https?://(?:api-gateway\\.dm\\.reform\\.hmcts\\.net|dm-store-prod\\.service\\.core-compute-prod\\.internal)"
+document_management_url = "^https?://(?:api-gateway\\.dm\\.reform\\.hmcts\\.net|dm-store-prod\\.service\\.core-compute-prod\\.internal(?::\\d+)?)"
 ccd_print_service_url = "https://return-case-doc.ccd.platform.hmcts.net"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-1961

### Change description ###

Documents URIs in CNP includes a port number, this PR add support for an optional port number.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
