### PR TITLE
RDM-2174

### DIFF
--- a/src/app/shared/case-editor/case-edit.component.spec.ts
+++ b/src/app/shared/case-editor/case-edit.component.spec.ts
@@ -1,5 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { ReactiveFormsModule } from '@angular/forms';
+import { ReactiveFormsModule, FormGroup, FormControl, Validators } from '@angular/forms';
 import { MockComponent } from 'ng2-mock-component';
 import { By } from '@angular/platform-browser';
 import { CaseEventTrigger } from '../domain/case-view/case-event-trigger.model';
@@ -174,6 +174,25 @@ describe('CaseEditComponent', () => {
     component.previous('somePage');
     expect(wizard.previousPage).toHaveBeenCalled();
     expect(routerStub.navigate).toHaveBeenCalled();
+  });
+
+  it('should reset invalid form fields when previous is called', () => {
+    component.wizard = wizard;
+    wizard.previousPage.and.returnValue(new WizardPage());
+
+    component.form.controls['data'] = new FormGroup({
+      invalidNotTouched: new FormControl('Jon', Validators.minLength(10)),
+      invalidTouched: new FormControl('Jan', Validators.minLength(10)),
+      valid: new FormControl('Drew'),
+    });
+    component.form.controls['data'].get('invalidTouched').markAsTouched();
+    wizard.previousPage.and.returnValue(new WizardPage());
+    fixture.detectChanges();
+    component.previous('somePage');
+
+    expect(component.form.controls['data'].get('invalidNotTouched').value).toBe('Jon');
+    expect(component.form.controls['data'].get('invalidTouched').value).toBeNull();
+    expect(component.form.controls['data'].get('valid').value).toBe('Drew');
   });
 
   it('should navigate to the page when navigateToPage is called', () => {

--- a/src/app/shared/case-editor/case-edit.component.ts
+++ b/src/app/shared/case-editor/case-edit.component.ts
@@ -85,11 +85,10 @@ export class CaseEditComponent implements OnInit {
 
   previous(currentPageId: string): Promise<boolean> {
     let previousPage = this.wizard.previousPage(currentPageId, this.buildCanShowPredicate());
-
     if (!previousPage) {
       return Promise.resolve(false);
     }
-
+    this.resetInvalidFormFields();
     return this.router.navigate([previousPage.id], { relativeTo: this.route });
   }
 
@@ -104,5 +103,14 @@ export class CaseEditComponent implements OnInit {
   confirm(confirmation: Confirmation): Promise<boolean> {
     this.confirmation = confirmation;
     return this.router.navigate(['confirm'], {relativeTo: this.route});
+  }
+
+  private resetInvalidFormFields() {
+    Object.keys(this.form.controls['data'].value).forEach(key => {
+      const control = this.form.controls['data'].get(key);
+      if (control.touched && control.invalid) {
+        control.reset();
+      }
+    });
   }
 }


### PR DESCRIPTION
To fix the bug the best approach is to reset invalid form fields when navigating on previous page

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
