### PR TITLE
fixed broken back navigation caused by label component not being able…

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@angular/platform-server": "~5.0.0",
     "@angular/router": "~5.0.0",
     "@angular/upgrade": "~5.0.0",
-    "@hmcts/ccd-case-ui-toolkit": "1.0.3",
+    "@hmcts/ccd-case-ui-toolkit": "1.0.4",
     "@nguniversal/express-engine": "^5.0.0-beta.5",
     "@nguniversal/module-map-ngfactory-loader": "^5.0.0-beta.5",
     "class-transformer": "^0.1.8",

--- a/src/app/shared/substitutor/label-substitutor.directive.spec.ts
+++ b/src/app/shared/substitutor/label-substitutor.directive.spec.ts
@@ -423,7 +423,7 @@ describe('LabelSubstitutorDirective', () => {
             expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '7 Mar 2018' }, label);
         });
 
-        it('should pass form field value with invalid date', () => {
+        it('should pass form field value with invalid date when both form and case field values present', () => {
           let label = 'someLabel';
           comp.caseField = field('LabelB', '', {
               id: 'LabelB',

--- a/src/app/shared/substitutor/label-substitutor.directive.spec.ts
+++ b/src/app/shared/substitutor/label-substitutor.directive.spec.ts
@@ -384,7 +384,7 @@ describe('LabelSubstitutorDirective', () => {
             }, '')];
             fixture.detectChanges();
 
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '07-03-2018' }, label);
+            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '7 Mar 2018' }, label);
         });
 
         it('should pass form field value with Date when form field value but no case field value present', () => {
@@ -402,7 +402,7 @@ describe('LabelSubstitutorDirective', () => {
             });
             fixture.detectChanges();
 
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '07-03-2018' }, label);
+            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '7 Mar 2018' }, label);
         });
 
         it('should pass form field value with Date when both form and case field values present', () => {
@@ -420,8 +420,26 @@ describe('LabelSubstitutorDirective', () => {
             });
             fixture.detectChanges();
 
-            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '07-03-2018' }, label);
+            expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '7 Mar 2018' }, label);
         });
+
+        it('should pass form field value with invalid date', () => {
+          let label = 'someLabel';
+          comp.caseField = field('LabelB', '', {
+              id: 'LabelB',
+              type: 'Text'
+          },  label);
+          comp.eventFields = [comp.caseField, field('LabelA', '2018-03', {
+              id: 'LabelA',
+              type: 'Date'
+          }, '')];
+          comp.formGroup = new FormGroup({
+              LabelA: new FormControl('2018-03')
+          });
+          fixture.detectChanges();
+
+          expect(labelSubstitutionService.substituteLabel).toHaveBeenCalledWith({ LabelB: '', LabelA: '{ Invalid Date: 2018-03 }' }, label);
+      });
     });
 
     describe('Collection type fields', () => {
@@ -725,7 +743,7 @@ describe('LabelSubstitutorDirective', () => {
                 type: 'Text'
             },  label);
             const RAW_VALUES = [{value: '2018-03-07'}, {value: '2015-02-22'}, {value: '2017-12-12'}];
-            const TRANSFORMED_VALUES = [{value: '07-03-2018'}, {value: '22-02-2015'}, {value: '12-12-2017'}];
+            const TRANSFORMED_VALUES = [{value: '7 Mar 2018'}, {value: '22 Feb 2015'}, {value: '12 Dec 2017'}];
             comp.eventFields = [comp.caseField, field('LabelA', RAW_VALUES, {
                 id: 'LabelA',
                 type: 'Collection',
@@ -746,7 +764,7 @@ describe('LabelSubstitutorDirective', () => {
                 type: 'Text'
             },  label);
             const RAW_VALUES = [{value: '2018-03-07'}, {value: '2015-02-22'}, {value: '2017-12-12'}];
-            const TRANSFORMED_VALUES = [{value: '07-03-2018'}, {value: '22-02-2015'}, {value: '12-12-2017'}];
+            const TRANSFORMED_VALUES = [{value: '7 Mar 2018'}, {value: '22 Feb 2015'}, {value: '12 Dec 2017'}];
               comp.eventFields = [comp.caseField, field('LabelA', [], {
                 id: 'LabelA',
                 type: 'Collection',
@@ -770,7 +788,7 @@ describe('LabelSubstitutorDirective', () => {
                 type: 'Text'
             },  label);
             const RAW_VALUES = [{value: '2018-03-07'}, {value: '2015-02-22'}, {value: '2017-12-12'}];
-            const TRANSFORMED_VALUES = [{value: '07-03-2018'}, {value: '22-02-2015'}, {value: '12-12-2017'}];
+            const TRANSFORMED_VALUES = [{value: '7 Mar 2018'}, {value: '22 Feb 2015'}, {value: '12 Dec 2017'}];
             comp.eventFields = [comp.caseField, field('LabelA', [{value: 'ValueD'}, {value: 'ValueD'}, {value: 'ValueD'}], {
                 id: 'LabelA',
                 type: 'Collection',

--- a/src/app/shared/utils/fields.utils.ts
+++ b/src/app/shared/utils/fields.utils.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 import { CaseField } from '../domain/definition/case-field.model';
-import { CurrencyPipe, DatePipe } from '@angular/common';
+import { CurrencyPipe, } from '@angular/common';
+import { DatePipe } from '../palette/utils/date.pipe';
 
 @Injectable()
 export class FieldsUtils {
 
   private static readonly currencyPipe: CurrencyPipe = new CurrencyPipe('en-GB');
-  private static readonly datePipe: DatePipe = new DatePipe('en-GB');
+  private static readonly datePipe: DatePipe = new DatePipe();
   public static readonly LABEL_SUFFIX = '-LABEL';
 
   public static toValuesMap(caseFields: CaseField[]): any {
@@ -76,12 +77,20 @@ export class FieldsUtils {
   }
 
   private static getDate(fieldValue) {
-    return FieldsUtils.datePipe.transform(fieldValue, 'dd-MM-yyyy');
+    try {
+      return FieldsUtils.datePipe.transform(fieldValue, 'dd-MM-yyyy');
+    } catch (e) {
+      return this.textForInvalidField('Date', fieldValue);
+    }
   }
 
   private static getFixedListLabelByCodeOrEmpty(field, code) {
     let relevantItem = code ? field.field_type.fixed_list_items.find(item => item.code === code) : '';
     return relevantItem ? relevantItem.label : '';
+  }
+
+  private static textForInvalidField(type: string, invalidValue: string): string {
+    return `{ Invalid ${type}: ${invalidValue} }`;
   }
 
   mergeCaseFieldsAndFormFields(caseFields: CaseField[], formFields: any): any {
@@ -103,4 +112,5 @@ export class FieldsUtils {
   private cloneObject(obj: any): any {
     return Object.assign({}, obj);
   }
+
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -168,9 +168,9 @@
   dependencies:
     tslib "^1.7.1"
 
-"@hmcts/ccd-case-ui-toolkit@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@hmcts/ccd-case-ui-toolkit/-/ccd-case-ui-toolkit-1.0.3.tgz#4df85581036ed7226d391f1db5e3bb1c20af3d86"
+"@hmcts/ccd-case-ui-toolkit@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@hmcts/ccd-case-ui-toolkit/-/ccd-case-ui-toolkit-1.0.4.tgz#8d16c90a34604c4cdc35b84940bc5e8ee6df76d9"
   dependencies:
     govuk-elements-sass "^3.1.2"
 


### PR DESCRIPTION
The label component is going in exception when a form date field has an invalid date. This breaks the navigation. Fixed that
In case of invalid date, e.g. 13-05, the Label will output:
{ Invalid Date: 13-05 }

Also fixed wrong date format in label. At the moment is displayed as 05-05-1981 but should be 05 May 1981 like we have in the rest of the app

https://tools.hmcts.net/jira/browse/RDM-2174

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
