### PR TITLE
case-activity-url-parameter-switch

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -44,7 +44,7 @@ module "case-management-web" {
     CCD_GW_LOGOUT_URL = "${local.ccd_gateway_url}/logout"
     CCD_API_URL = "${local.ccd_gateway_url}/aggregated"
     CCD_DATA_URL = "${local.ccd_gateway_url}/data"
-    CCD_ACTIVITY_URL = "" // Activity disabled until it's deployed on CNP
+    CCD_ACTIVITY_URL = "${var.env != "saat" ? "" : "{local.ccd_gateway_url}/activity""
     CCD_GW_OAUTH2_URL = "${local.ccd_gateway_url}/oauth2"
     CCD_GW_OAUTH2_CLIENT_ID = "ccd_gateway"
     DM_URL = "${local.ccd_gateway_url}/documents"


### PR DESCRIPTION

This is a change to update configuration in order to toggle on and off the use of the case activity service by the front end. The change mean it is only enabled for a specific test environment.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```