### PR TITLE
Force use of HTTPS

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -40,6 +40,7 @@ module "case-management-web" {
   subscription = "${var.subscription}"
   is_frontend = "${local.is_frontend}"
   additional_host_name = "${local.external_host_name}"
+  https_only = "${var.https_only}"
 
   app_settings = {
     IDAM_LOGIN_URL = "${var.idam_authentication_web_url}/login"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -62,3 +62,7 @@ variable "external_host_name" {
 variable "aat_gateway" {
   default = "https://ccd-api-gateway-web-aat.service.core-compute-aat.internal"
 }
+
+variable "https_only" {
+  default = "true"
+}


### PR DESCRIPTION
### Change description ###
Use the webapp http_only switch to force exposed apps to only use HTTPS.

https://tools.hmcts.net/jira/browse/RDM-2367



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
