### PR TITLE
RDM-1705: Use trusted gateway URL for preview

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -6,8 +6,7 @@ locals {
   env_ase_url = "${var.env}.service.${data.terraform_remote_state.core_apps_compute.ase_name[0]}.internal"
 
   default_ccd_gateway_url = "https://ccd-api-gateway-web-${local.env_ase_url}"
-  non_preview_ccd_gateway_url = "${var.ccd_gateway_url != "" ? var.ccd_gateway_url : local.default_ccd_gateway_url}"
-  ccd_gateway_url = "${var.env == "preview" ? var.aat_gateway : local.non_preview_ccd_gateway_url}"
+  ccd_gateway_url = "${var.ccd_gateway_url != "" ? var.ccd_gateway_url : local.default_ccd_gateway_url}"
 
   default_ccd_print_service_url = "https://ccd-case-print-service-${local.env_ase_url}"
   ccd_print_service_url = "${var.ccd_print_service_url != "" ? var.ccd_print_service_url : local.default_ccd_print_service_url}"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-1705

### Change description ###

Use overridden `ccd_gateway_url` variable for preview, pointing to external AAT DNS.
The external DNS matching a valid certificate, the URL of the gateway should not cause security exception.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```