### PR TITLE
RDM-2360: Document upload errors are not reported correctly

### DIFF
--- a/src/app/shared/palette/document/write-document-field.component.ts
+++ b/src/app/shared/palette/document/write-document-field.component.ts
@@ -80,6 +80,6 @@ export class WriteDocumentFieldComponent extends AbstractFieldWriteComponent imp
       return 'Document upload facility is not available at the moment';
     }
 
-    return error.message;
+    return error.error;
   }
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-2360

### Change description ###
Upload of a document in CCD UI to Document store failing because of a non-whitelisted file type results in a generic error "Something unexpected happened" instead of indicating the actual error. (see attached screenshots).
Instead, the error returned by Document Store should be displayed to the user.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
