### PR TITLE
RDM-1508 - allow metadata to be first column in case list/search results

### DIFF
--- a/src/app/shared/search/search-result-view-column.model.ts
+++ b/src/app/shared/search/search-result-view-column.model.ts
@@ -1,8 +1,9 @@
-import { FieldType } from '../../shared/domain/definition/field-type.model';
+import { FieldType } from '../domain/definition/field-type.model';
 
 export class SearchResultViewColumn {
   case_field_id: string;
   case_field_type: FieldType;
   label: string;
   order: number;
+  metadata?: boolean;
 }

--- a/src/app/shared/search/search-result.component.spec.ts
+++ b/src/app/shared/search/search-result.component.spec.ts
@@ -388,7 +388,7 @@ describe('SearchResultComponent', () => {
           metadata: true
         },
         {
-          case_field_id: 'PersonFirstName',
+          case_field_id: 'FirstName',
           case_field_type: {
             id: 'Text',
             type: 'Text'
@@ -398,7 +398,7 @@ describe('SearchResultComponent', () => {
           metadata: false
         },
         {
-          case_field_id: 'PersonLastName',
+          case_field_id: 'LastName',
           case_field_type: {
             id: 'Text',
             type: 'Text'
@@ -413,24 +413,24 @@ describe('SearchResultComponent', () => {
           case_id: '0000000000000000',
           case_fields: {
             state: 'State1',
-            PersonFirstName: 'Janet',
-            PersonLastName: 'Parker',
+            FirstName: 'Janet',
+            LastName: 'Parker',
           }
         },
         {
           case_id: '0000000000000001',
           case_fields: {
             state: 'State2',
-            PersonFirstName: 'Steve',
-            PersonLastName: 'Jobs'
+            FirstName: 'Steve',
+            LastName: 'Jobs'
           }
         },
         {
           case_id: '0000000000000002',
           case_fields: {
             state: 'State3',
-            PersonFirstName: 'Bill',
-            PersonLastName: 'Gates'
+            FirstName: 'Bill',
+            LastName: 'Gates'
           }
         }
       ]
@@ -537,11 +537,12 @@ describe('SearchResultComponent', () => {
       let firstRowFirstCol = de.query(By.css('div>table>tbody tr:nth-child(1) td:nth-child(1) a'));
       expect(firstRowFirstCol.nativeElement.textContent.trim()).toBe(new CaseReferencePipe().transform(firstResult.case_fields['state']));
 
-      let firstRowComponentChildren = firstRow.children.slice(1, 3);
+      let firstRowComponent = firstRow.children.slice(1, 3);
+      let firstRowResult = RESULT_VIEW.results[0];
 
-      expect(firstRowComponentChildren[0].children[0].children[0].componentInstance.caseField.value === RESULT_VIEW.results[0].case_fields['PersonFirstName'])
+      expect(firstRowComponent[0].children[0].children[0].componentInstance.caseField.value === firstRowResult.case_fields['FirstName'])
         .toBeTruthy();
-      expect(firstRowComponentChildren[1].children[0].children[0].componentInstance.caseField.value === RESULT_VIEW.results[0].case_fields['PersonLastName'])
+      expect(firstRowComponent[1].children[0].children[0].componentInstance.caseField.value === firstRowResult.case_fields['LastName'])
         .toBeTruthy();
     });
 

--- a/src/app/shared/search/search-result.component.ts
+++ b/src/app/shared/search/search-result.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, OnChanges, SimpleChanges, EventEmitter } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
 import { SearchResultView } from './search-result-view.model';
 import { PaginationMetadata } from './pagination-metadata.model';
 import { SearchResultViewColumn } from './search-result-view-column.model';
@@ -6,8 +6,8 @@ import { SearchResultViewItemComparator } from './sorting/search-result-view-ite
 import { SortParameters } from './sorting/sort-parameters';
 import { SortOrder } from './sorting/sort-order';
 import { SearchResultViewItemComparatorFactory } from './sorting/search-result-view-item-comparator-factory';
-import { Jurisdiction } from '../../shared/domain/definition/jurisdiction.model';
-import { CaseState } from '../../shared/domain/definition/case-state.model';
+import { Jurisdiction } from '../domain/definition/jurisdiction.model';
+import { CaseState } from '../domain/definition/case-state.model';
 import { DisplayMode } from '../../core/activity/activity.model';
 import { AppConfig } from '../../app.config';
 import { CaseType } from '../domain/definition/case-type.model';
@@ -20,10 +20,6 @@ import { ActivityService } from '../../core/activity/activity.service';
   styleUrls: ['./search-result.scss']
 })
 export class SearchResultComponent implements OnChanges {
-
-  public static readonly PARAM_JURISDICTION = 'jurisdiction';
-  public static readonly PARAM_CASE_TYPE = 'case-type';
-  public static readonly PARAM_CASE_STATE = 'case-state';
 
   ICON = DisplayMode.ICON;
 
@@ -55,6 +51,8 @@ export class SearchResultComponent implements OnChanges {
 
   hideRows: boolean;
 
+  showCaseIdColumn: boolean;
+
   selected: {
     init?: boolean,
     jurisdiction?: Jurisdiction,
@@ -72,6 +70,7 @@ export class SearchResultComponent implements OnChanges {
     this.searchResultViewItemComparatorFactory = searchResultViewItemComparatorFactory;
     this.paginationPageSize = appConfig.getPaginationPageSize();
     this.hideRows = false;
+    this.showCaseIdColumn = true;
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -89,6 +88,9 @@ export class SearchResultComponent implements OnChanges {
       this.resultView.columns = this.resultView.columns.sort((a: SearchResultViewColumn, b: SearchResultViewColumn) => {
         return a.order - b.order;
       });
+
+      // Show case id column when the first column in results in not a metadata field
+      this.showCaseIdColumn = !(this.resultView.columns.length > 0 && this.resultView.columns[0].metadata);
     }
     if (changes['page']) {
       this.selected.page = (changes['page']).currentValue;

--- a/src/app/shared/search/search-result.html
+++ b/src/app/shared/search/search-result.html
@@ -1,7 +1,7 @@
 <table *ngIf="hasResults()">
   <thead>
   <tr>
-    <th class="search-result-column-label">Case reference</th>
+    <th *ngIf="showCaseIdColumn" class="search-result-column-label">Case reference</th>
     <th *ngFor="let col of resultView.columns">
       <table class="search-result-column-header">
         <tr>
@@ -17,11 +17,21 @@
   </thead>
   <tbody>
   <tr *ngFor="let result of resultView.results | ccdSortSearchResult : sortParameters | paginate: { itemsPerPage: paginationPageSize, currentPage: selected.page, totalItems: paginationMetadata.total_results_count }">
-    <td class="caseid-col">
+    <td *ngIf="showCaseIdColumn" class="caseid-col">
       <a routerLink="/case/{{jurisdiction.id}}/{{caseType.id}}/{{result.case_id}}"><div class="text-16" [style.visibility]="hideRows ? 'hidden' : 'visible'">{{result.case_id | ccdCaseReference}}</div></a>
     </td>
-    <td *ngFor="let col of resultView.columns">
-      <div class="text-16" [style.visibility]="hideRows ? 'hidden' : 'visible'">
+    <td *ngFor="let col of resultView.columns; let colIndex = index">
+      <a *ngIf="colIndex==0 && !showCaseIdColumn" routerLink="/case/{{jurisdiction.id}}/{{caseType.id}}/{{result.case_id}}">
+        <div class="text-16" [style.visibility]="hideRows ? 'hidden' : 'visible'">
+          <ccd-field-read [caseField]="{
+                  id: col.case_field_id,
+                  label: col.label,
+                  field_type: col.case_field_type,
+                  value: result.case_fields[col.case_field_id]
+            }"></ccd-field-read>
+        </div>
+      </a>
+      <div *ngIf="colIndex!=0 || showCaseIdColumn" class="text-16" [style.visibility]="hideRows ? 'hidden' : 'visible'">
         <ccd-field-read [caseField]="{
                 id: col.case_field_id,
                 label: col.label,


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-1508


### Change description : ###
UI changes to show metadata field as first column for search results when configured in definition import as first column otherwise show case reference as first column. The import part of defining metadata fields in work basket result fields or search result fields has been already covered by previous PRs on story (RDM-1240)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
