### PR TITLE
RDM-2432: Document upload - Chosen file name is not retained

### DIFF
--- a/src/app/shared/palette/document/write-document-field.component.ts
+++ b/src/app/shared/palette/document/write-document-field.component.ts
@@ -37,7 +37,6 @@ export class WriteDocumentFieldComponent extends AbstractFieldWriteComponent imp
       let documentUpload: FormData = new FormData();
       documentUpload.append('files', this.selectedFile, this.selectedFile.name);
       documentUpload.append('classification', 'PUBLIC');
-      this.caseField.value = this.selectedFile.name;
       this.documentManagement.uploadFile(documentUpload).subscribe(result => {
         if (!this.uploadedDocument) {
           this.createDocumentGroup();
@@ -49,7 +48,7 @@ export class WriteDocumentFieldComponent extends AbstractFieldWriteComponent imp
           document._links.binary.href,
           document.originalDocumentName,
         );
-
+        this.caseField.value = this.selectedFile.name;
         this.valid = true;
       }, (error: HttpError) => {
         this.uploadError = this.getErrorMessage(error);

--- a/src/app/shared/palette/document/write-document-field.component.ts
+++ b/src/app/shared/palette/document/write-document-field.component.ts
@@ -37,6 +37,7 @@ export class WriteDocumentFieldComponent extends AbstractFieldWriteComponent imp
       let documentUpload: FormData = new FormData();
       documentUpload.append('files', this.selectedFile, this.selectedFile.name);
       documentUpload.append('classification', 'PUBLIC');
+      this.caseField.value = this.selectedFile.name;
       this.documentManagement.uploadFile(documentUpload).subscribe(result => {
         if (!this.uploadedDocument) {
           this.createDocumentGroup();

--- a/src/app/shared/palette/document/write-document-field.html
+++ b/src/app/shared/palette/document/write-document-field.html
@@ -8,6 +8,7 @@
 
   <div>
     <ccd-read-document-field *ngIf="caseField" [caseField]="caseField"></ccd-read-document-field>
+    <div class="chosen-file" *ngIf="selectedFile && selectedFile.name && caseField.value">Chosen file: {{ caseField.value }}</div>
   </div>
 
   <input class="form-control bottom-30" [id]="id()" type="file" (change)="fileChangeEvent($event)"/>

--- a/src/style/app.scss
+++ b/src/style/app.scss
@@ -199,3 +199,8 @@ select::-ms-expand {
 .markdown ul, .markdown p {
   margin-bottom: 25px;
 }
+.chosen-file {
+  width: 60%;
+  float: right;
+  text-align: right;
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-2432


### Change description ###
Document upload: Chosen file name is not retained when user navigates back to the previous page.

Steps to repro:

ChooStylese a file by clicking browse button, file name appears next to 'Browse' button
Click Continue to navigate to next page
Again click Previous button on the next page to navigate back to the previous page
Expected: Chosen file name should appear in the 'Document URL' next to Browse button

Actual : Chosen file name disappear from the Document URL box. However, the document gets uploaded when the case/event is submitted.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
