### PR TITLE
Fix: Docker image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,7 @@
 !yarn.lock
 !src/
 !docker/
-!.angular-cli.json
+!angular.json
 !tsconfig.json
 !webpack.server.config.js
 !server.ts


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Docker image build broke during Angular 6 migration as `.angular-cli.json` was renamed to `angular.json`
Stop ignoring angular.json file required for Docker build

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```