### PR TITLE
Yarn: add 180s network timeout

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+network-timeout "180000"


### PR DESCRIPTION
We seem to hit many timeout issues in Jenkins, try avoid these by giving
a 3 minute timeout.









**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```