### PR TITLE
RDM-3067: Switch login DNS

### DIFF
--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,4 +1,4 @@
-idam_authentication_web_url = "https://www.idam.platform.hmcts.net"
+idam_authentication_web_url = "https://hmcts-access.service.gov.uk"
 ccd_gateway_url = "https://gateway.ccd.platform.hmcts.net"
 document_management_url = "^https?://(?:api-gateway\\.dm\\.reform\\.hmcts\\.net|dm-store-prod\\.service\\.core-compute-prod\\.internal(?::\\d+)?)"
 ccd_print_service_url = "https://return-case-doc.ccd.platform.hmcts.net"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-3067

### Change description ###

- Change login DNS from `platform.hmcts.net` to `hmcts-access.service.gov.uk`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
