### PR TITLE
Temporarily disable vault reading

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -43,7 +43,7 @@ withNightlyPipeline(type, product, app) {
         enableCrossBrowserTest()
     }
 
-    loadVaultSecrets(secrets)
+    //loadVaultSecrets(secrets)
     env.TEST_URL = params.TEST_URL_PARAM
     env.CCD_CASEWORKER_AUTOTEST_EMAIL = params.AUTOTEST_EMAIL_PARAM
     env.CCD_CASEWORKER_AUTOTEST_PASSWORD = params.AUTOTEST_PASSWORD_PARAM


### PR DESCRIPTION
The upstream code hasn't quite sorted out vault access on nightly build
runs, so disable temporarily.





https://tools.hmcts.net/jira/browse/RDM-3295





**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```