### PR TITLE
optimise docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,34 @@
-FROM node:8.12.0-slim
-
-RUN mkdir -p /usr/src/app
-
+# ---- Base Image ----
+FROM node:8.12.0-slim AS base
 WORKDIR /usr/src/app
-
-ARG BUILD_DEPS='bzip2 patch'
-
-COPY package.json yarn.lock .snyk /usr/src/app/
-RUN apt-get update && apt-get install -y $BUILD_DEPS --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/* \
-    && yarn install
-
-COPY . /usr/src/app/
-
+ARG BUILD_DEPS='bzip2 patch libfontconfig'
+RUN apt-get update \
+    && apt-get install -y $BUILD_DEPS --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+# ---- Dependencies ----
+# This image has all dependencies for all build tasks, frontend,
+# backend, unit tests, and even selenium test runner/webdrivers.
+# It can be used as a base image for any build or test run.
+FROM base AS dependencies
+COPY package.json yarn.lock .snyk ./
+RUN yarn install
+# ---- Copy source files ----
+# This image can be used for different codebase-related
+# tasks like unit tests or code quality checks.
+FROM dependencies AS with-source
+COPY . .
+# ---- Build artifacts ----
+# Both frontend and backend codebases are bundled from their
+# .ts source into .js, producing self-sufficient scripts.
+# Notice the nodejs codebase build also incorporates its
+# own dependencies bundled within a single file.
+FROM with-source AS build
 RUN yarn build:ssr
-
-RUN rm -rf node_modules \
-    && yarn install --production \
-    && apt-get purge -y --auto-remove $BUILD_DEPS
-
+# ---- Runtime image ----
+# Starting from a fresh node base image: no need for another
+# npm install as the built artifacts have their dependencies
+# built-in already, as stated above.
+FROM node:8.12.0-slim AS runtime
 WORKDIR /usr/src/app/dist
+COPY --from=build /usr/src/app/dist/ ./
 CMD node ./server.js


### PR DESCRIPTION

### JIRA link (if applicable) ###



### Change description ###

```
Optimise the docker build directives

This commit introduces multi-staging build:
- by starting from a base image to build the runtime image the size is reduced by 8x (~1.6 GB > 200MB)
- the different targets allow a fine grained control over which image you want to produce for a given purpose

Other PRs might follow to reduce the duration of the docker build time as well as deferring some tasks
like unit tests and docker images layers reuse to an ACR (azure container registry).
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
