### PR TITLE
RDM-3463: Update to Version 2.8.1 of ccd-case-ui-toolkit library

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@angular/platform-server": "~7.0.3",
     "@angular/router": "~7.0.3",
     "@angular/upgrade": "~7.0.3",
-    "@hmcts/ccd-case-ui-toolkit": "2.8.0",
+    "@hmcts/ccd-case-ui-toolkit": "2.8.1",
     "@hmcts/ccpay-web-component": "~1.8.1",
     "@nguniversal/express-engine": "^6.0.0",
     "@nguniversal/module-map-ngfactory-loader": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -299,9 +299,10 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@hmcts/ccd-case-ui-toolkit@2.8.0":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@hmcts/ccd-case-ui-toolkit/-/ccd-case-ui-toolkit-2.8.0.tgz#e2d230827b86ab2e6f7bff67d7e6d112bcaf75f1"
+"@hmcts/ccd-case-ui-toolkit@2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@hmcts/ccd-case-ui-toolkit/-/ccd-case-ui-toolkit-2.8.1.tgz#596bec851b003ccf6187d3e3c15cf34ab6221b39"
+  integrity sha512-YsFEi6NxEDZwb1jwvNVg0DMC4rG4nj+lgnrQTV32wjJI9pbgFLgpQ3ilzW+kQMYS+8Chg5+UQj06OiPGuH8vcQ==
   dependencies:
     "@angular/cli" "^6.0.8"
     "@angular/compiler-cli" "~7.0.3"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-3463.

### Change description ###
Update to use Version 2.8.1 of ccd-case-ui-toolkit, which fixes a vulnerability with dependency on the third-party `event-stream` library.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
