### PR TITLE
Revert to V1 endpoints to fix Resume drafts in PROD.

### DIFF
--- a/src/app/cases/creator/create-case-event-trigger.resolver.spec.ts
+++ b/src/app/cases/creator/create-case-event-trigger.resolver.spec.ts
@@ -33,7 +33,7 @@ describe('CreateCaseFieldsResolver', () => {
   let route: any;
 
   beforeEach(() => {
-    casesService = createSpyObj('casesService', ['getEventTriggerV2']);
+    casesService = createSpyObj('casesService', ['getEventTrigger']);
     alertService = createSpyObj('alertService', ['error']);
 
     createCaseFieldsResolver = new CreateCaseEventTriggerResolver(casesService, alertService);
@@ -63,7 +63,7 @@ describe('CreateCaseFieldsResolver', () => {
   });
 
   it('should resolve event trigger and cache when route is :jid/:ctid/:eid', () => {
-    casesService.getEventTriggerV2.and.returnValue(EVENT_TRIGGER_OBS);
+    casesService.getEventTrigger.and.returnValue(EVENT_TRIGGER_OBS);
     expect(createCaseFieldsResolver['cachedEventTrigger']).toBeUndefined();
 
     createCaseFieldsResolver
@@ -72,13 +72,13 @@ describe('CreateCaseFieldsResolver', () => {
         expect(triggerData).toBe(EVENT_TRIGGER);
       });
 
-    expect(casesService.getEventTriggerV2).toHaveBeenCalledWith(
-      CASE_TYPE, EVENT_TRIGGER_ID, undefined, String(IGNORE_WARNINGS));
+    expect(casesService.getEventTrigger).toHaveBeenCalledWith(
+      JURISDICTION, CASE_TYPE, EVENT_TRIGGER_ID, undefined, String(IGNORE_WARNINGS));
     expect(route.paramMap.get).toHaveBeenCalledWith(PARAM_CASE_TYPE_ID);
     expect(route.paramMap.get).toHaveBeenCalledWith(PARAM_EVENT_ID);
     expect(route.queryParamMap.get).toHaveBeenCalledWith(QUERY_PARAM_IGNORE_WARNINGS);
     expect(route.queryParamMap.get).toHaveBeenCalledWith(DRAFT_QUERY_PARAM);
-    expect(route.paramMap.get).toHaveBeenCalledTimes(2);
+    expect(route.paramMap.get).toHaveBeenCalledTimes(3);
     expect(route.queryParamMap.get).toHaveBeenCalledTimes(2);
     expect(createCaseFieldsResolver['cachedEventTrigger']).toBe(EVENT_TRIGGER);
   });
@@ -91,7 +91,7 @@ describe('CreateCaseFieldsResolver', () => {
       queryParamMap : createSpyObj('queryParamMap', ['get']),
       paramMap: createSpyObj('paramMap', ['get'])
     };
-    casesService.getEventTriggerV2.and.returnValue(EVENT_TRIGGER_OBS);
+    casesService.getEventTrigger.and.returnValue(EVENT_TRIGGER_OBS);
     expect(createCaseFieldsResolver['cachedEventTrigger']).toBeUndefined();
 
     createCaseFieldsResolver
@@ -100,7 +100,7 @@ describe('CreateCaseFieldsResolver', () => {
         expect(triggerData).toBe(EVENT_TRIGGER);
       });
 
-    expect(casesService.getEventTriggerV2).toHaveBeenCalled();
+    expect(casesService.getEventTrigger).toHaveBeenCalled();
     expect(route.paramMap.get).toHaveBeenCalledWith(PARAM_EVENT_ID);
     expect(createCaseFieldsResolver['cachedEventTrigger']).toBe(EVENT_TRIGGER);
   });
@@ -113,7 +113,7 @@ describe('CreateCaseFieldsResolver', () => {
       queryParamMap : createSpyObj('queryParamMap', ['get']),
       paramMap: createSpyObj('paramMap', ['get'])
     };
-    casesService.getEventTriggerV2.and.returnValue(EVENT_TRIGGER_OBS);
+    casesService.getEventTrigger.and.returnValue(EVENT_TRIGGER_OBS);
     createCaseFieldsResolver['cachedEventTrigger'] = EVENT_TRIGGER;
 
     createCaseFieldsResolver
@@ -122,7 +122,7 @@ describe('CreateCaseFieldsResolver', () => {
         expect(triggerData).toBe(EVENT_TRIGGER);
       });
 
-    expect(casesService.getEventTriggerV2).not.toHaveBeenCalled();
+    expect(casesService.getEventTrigger).not.toHaveBeenCalled();
     expect(createCaseFieldsResolver['cachedEventTrigger']).toBe(EVENT_TRIGGER);
   });
 
@@ -135,7 +135,7 @@ describe('CreateCaseFieldsResolver', () => {
           return DRAFT_ID;
       }
     });
-    casesService.getEventTriggerV2.and.returnValue(EVENT_TRIGGER_OBS);
+    casesService.getEventTrigger.and.returnValue(EVENT_TRIGGER_OBS);
 
     createCaseFieldsResolver
       .resolve(route)
@@ -143,17 +143,17 @@ describe('CreateCaseFieldsResolver', () => {
         expect(triggerData).toBe(EVENT_TRIGGER);
       });
 
-    expect(casesService.getEventTriggerV2).toHaveBeenCalledWith(
-      CASE_TYPE, EVENT_TRIGGER_ID, DRAFT_ID, String(IGNORE_WARNINGS));
+    expect(casesService.getEventTrigger).toHaveBeenCalledWith(
+      JURISDICTION, CASE_TYPE, EVENT_TRIGGER_ID, DRAFT_ID, String(IGNORE_WARNINGS));
     expect(route.paramMap.get).toHaveBeenCalledWith(PARAM_CASE_TYPE_ID);
     expect(route.paramMap.get).toHaveBeenCalledWith(PARAM_EVENT_ID);
     expect(route.queryParamMap.get).toHaveBeenCalledWith(QUERY_PARAM_IGNORE_WARNINGS);
-    expect(route.paramMap.get).toHaveBeenCalledTimes(2);
+    expect(route.paramMap.get).toHaveBeenCalledTimes(3);
     expect(route.queryParamMap.get).toHaveBeenCalledTimes(2);
   });
 
   it('should create error alert when event trigger cannot be retrieved', done => {
-    casesService.getEventTriggerV2.and.returnValue(Observable.throw(ERROR));
+    casesService.getEventTrigger.and.returnValue(Observable.throw(ERROR));
 
     createCaseFieldsResolver
       .resolve(route)

--- a/src/app/cases/creator/create-case-event-trigger.resolver.ts
+++ b/src/app/cases/creator/create-case-event-trigger.resolver.ts
@@ -28,6 +28,7 @@ export class CreateCaseEventTriggerResolver implements Resolve<CaseEventTrigger>
   }
 
   getAndCacheEventTrigger(route: ActivatedRouteSnapshot): Observable<CaseEventTrigger> {
+    let jurisdictionId = route.paramMap.get(CreateCaseEventTriggerResolver.PARAM_JURISDICTION_ID);
     let caseTypeId = route.paramMap.get(CreateCaseEventTriggerResolver.PARAM_CASE_TYPE_ID);
     let eventTriggerId = route.paramMap.get(CreateCaseEventTriggerResolver.PARAM_EVENT_ID);
     let ignoreWarning = route.queryParamMap.get(CreateCaseEventTriggerResolver.QUERY_PARAM_IGNORE_WARNING);
@@ -41,7 +42,7 @@ export class CreateCaseEventTriggerResolver implements Resolve<CaseEventTrigger>
       caseId = draftId;
     }
     return this.casesService
-      .getEventTriggerV2(caseTypeId, eventTriggerId, caseId, ignoreWarning)
+      .getEventTrigger(jurisdictionId, caseTypeId, eventTriggerId, caseId, ignoreWarning)
       .do(eventTrigger => this.cachedEventTrigger = eventTrigger)
       .catch((error: HttpError) => {
         this.alertService.error(error.message);


### PR DESCRIPTION

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
