### PR TITLE
[PREVIEW] RDM-3655: Contents of a long fields are truncated when displayed

### DIFF
--- a/src/style/app.scss
+++ b/src/style/app.scss
@@ -220,6 +220,7 @@ select::-ms-expand {
 .text-16, .error-message {
   font-size: 16px;
   font-family: "nta", Arial, sans-serif;
+  white-space: normal;
 }
 .postcodeinput {
   width: 49%;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-3655

### Change description ###
Fields are being truncated when displayed on CaseTabs

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
