### PR TITLE
Revert "Rdm 3565 UI Toolkit: Use Get CaseHistoryForEvent API v2"

### DIFF
--- a/src/app/app.config.spec.ts
+++ b/src/app/app.config.spec.ts
@@ -29,7 +29,7 @@ describe('AppConfig', () => {
   const IE_MIN_REQUIRED_VERSION = 11;
   const EDGE_MIN_REQUIRED_VERSION = 17;
   const FIREFOX_MIN_REQUIRED_VERSION = 60;
-  const CASE_HISTORY_URL = DATA_URL + '/internal/cases/CID/events/EID';
+  const CASE_HISTORY_URL = API_URL + '/caseworkers/:uid/jurisdictions/JID/case-types/CTID/cases/CID/events/EID/case-history';
   const CREATE_OR_UPDATE_DRAFT_URL = DATA_URL + '/internal/case-types/CTID/drafts/';
   const VIEW_OR_DELETE_DRAFT_URL = DATA_URL + '/internal/drafts/DID';
 
@@ -107,7 +107,7 @@ describe('AppConfig', () => {
             expect(appConfig.getIEMinRequiredVersion()).toEqual(IE_MIN_REQUIRED_VERSION);
             expect(appConfig.getEdgeMinRequiredVersion()).toEqual(EDGE_MIN_REQUIRED_VERSION);
             expect(appConfig.getFirefoxMinRequiredVersion()).toEqual(FIREFOX_MIN_REQUIRED_VERSION);
-            expect(appConfig.getCaseHistoryUrl('CID', 'EID')).toEqual(CASE_HISTORY_URL);
+            expect(appConfig.getCaseHistoryUrl('JID', 'CTID', 'CID', 'EID')).toEqual(CASE_HISTORY_URL);
             expect(appConfig.getCreateOrUpdateDraftsUrl('CTID')).toEqual(CREATE_OR_UPDATE_DRAFT_URL);
             expect(appConfig.getViewOrDeleteDraftsUrl('DID')).toEqual(VIEW_OR_DELETE_DRAFT_URL);
           });

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -133,12 +133,18 @@ export class AppConfig extends AbstractAppConfig {
     return this.config.firefox_min_required_version;
   }
 
-  public getCaseHistoryUrl(caseId: string, eventId: string) {
-    return this.getCaseDataUrl()
-      + `/internal`
+  public getCaseHistoryUrl(jurisdictionId: string,
+                           caseTypeId: string,
+                           caseId: string,
+                           eventId: string) {
+    return this.getApiUrl()
+      + `/caseworkers/:uid`
+      + `/jurisdictions/${jurisdictionId}`
+      + `/case-types/${caseTypeId}`
       + `/cases/${caseId}`
-      + `/events/${eventId}`;
-}
+      + `/events/${eventId}`
+      + `/case-history`;
+  }
 
   public getCreateOrUpdateDraftsUrl(ctid: string) {
     return this.getCaseDataUrl() + `/internal/case-types/${ctid}/drafts/`;

--- a/src/app/core/cases/case-history.service.spec.ts
+++ b/src/app/core/cases/case-history.service.spec.ts
@@ -1,4 +1,4 @@
-import { Response, ResponseOptions, Headers } from '@angular/http';
+import { Response, ResponseOptions } from '@angular/http';
 import { AppConfig } from '../../app.config';
 import { Observable } from 'rxjs';
 import { CaseHistory } from './case-history.model';
@@ -9,10 +9,13 @@ import { HttpService, HttpError, HttpErrorService } from '@hmcts/ccd-case-ui-too
 
 describe('CaseHistoryService', () => {
 
-  const DATA_URL = 'http://data.ccd.reform';
+  const API_URL = 'http://aggregated.ccd.reform';
+  const JID = 'TEST';
+  const CTID = 'TestAddressBookCase';
   const CASE_ID = '1';
   const EVENT_ID = '10';
-  const CASE_HISTORY_URL = DATA_URL + `/internal/cases/${CASE_ID}/events/${EVENT_ID}`;
+  const CASE_HISTORY_URL = API_URL + `/caseworkers/:uid/jurisdictions/${JID}/case-types/${CTID}/cases/${CASE_ID}`
+    + `/events/${EVENT_ID}/case-history`;
   const ERROR: HttpError = new HttpError();
   ERROR.message = 'Critical error!';
 
@@ -43,19 +46,15 @@ describe('CaseHistoryService', () => {
 
     it('should use HttpService::get with correct url', () => {
       caseHistoryService
-        .get(CASE_ID, EVENT_ID)
+        .get(JID, CTID, CASE_ID, EVENT_ID)
         .subscribe();
 
-      expect(httpService.get).toHaveBeenCalledWith(CASE_HISTORY_URL, {
-        headers: new Headers({
-          'experimental': 'true',
-          'Accept': CaseHistoryService.V2_MEDIATYPE_CASE_EVENT_VIEW
-        })});
+      expect(httpService.get).toHaveBeenCalledWith(CASE_HISTORY_URL);
     });
 
     it('should retrieve case history from server', () => {
       caseHistoryService
-        .get(CASE_ID, EVENT_ID)
+        .get(JID, CTID, CASE_ID, EVENT_ID)
         .subscribe(
           caseHistory => expect(caseHistory).toEqual(CASE_HISTORY)
         );
@@ -65,7 +64,7 @@ describe('CaseHistoryService', () => {
       httpService.get.and.returnValue(Observable.throw(ERROR));
 
       caseHistoryService
-        .get(CASE_ID, EVENT_ID)
+        .get(JID, CTID, CASE_ID, EVENT_ID)
         .subscribe(() => {
         }, err => {
           expect(err).toEqual(ERROR);

--- a/src/app/core/cases/case-history.service.ts
+++ b/src/app/core/cases/case-history.service.ts
@@ -4,29 +4,23 @@ import { AppConfig } from '../../app.config';
 import { CaseHistory } from './case-history.model';
 import { plainToClass } from 'class-transformer';
 import { HttpService, HttpErrorService } from '@hmcts/ccd-case-ui-toolkit';
-import { Headers } from '@angular/http';
 
 @Injectable()
 export class CaseHistoryService {
-  public static readonly V2_MEDIATYPE_CASE_EVENT_VIEW =
-    'application/vnd.uk.gov.hmcts.ccd-data-store-api.ui-event-view.v2+json;charset=UTF-8';
 
   constructor(private httpService: HttpService,
               private httpErrorService: HttpErrorService,
               private appConfig: AppConfig) {}
 
-  get(caseId: string,
+  get(jurisdictionId: string,
+      caseTypeId: string,
+      caseId: string,
       eventId: string): Observable<CaseHistory> {
 
-    const url = this.appConfig.getCaseHistoryUrl(caseId, eventId);
-
-    let headers = new Headers({
-      'experimental': 'true',
-      'Accept': CaseHistoryService.V2_MEDIATYPE_CASE_EVENT_VIEW
-    });
+    const url = this.appConfig.getCaseHistoryUrl(jurisdictionId, caseTypeId, caseId, eventId);
 
     return this.httpService
-      .get(url, {headers})
+      .get(url)
       .map(response => response.json())
       .catch((error: any): any => {
         this.httpErrorService.setError(error);

--- a/src/app/shared/case-history/case-history.resolver.spec.ts
+++ b/src/app/shared/case-history/case-history.resolver.spec.ts
@@ -66,7 +66,7 @@ describe('CaseHistoryResolver', () => {
         });
 
       expect(route.paramMap.get).toHaveBeenCalledWith(CaseHistoryResolver.PARAM_EVENT_ID);
-      expect(caseHistoryService.get).toHaveBeenCalledWith(CASE_ID, EVENT_ID);
+      expect(caseHistoryService.get).toHaveBeenCalledWith(JURISDICTION_ID, CASE_TYPE_ID, CASE_ID, EVENT_ID);
     });
 
     it('should redirect to error page when case history cannot be retrieved', () => {

--- a/src/app/shared/case-history/case-history.resolver.ts
+++ b/src/app/shared/case-history/case-history.resolver.ts
@@ -16,14 +16,16 @@ export class CaseHistoryResolver implements Resolve<CaseHistory> {
 
   resolve(route: ActivatedRouteSnapshot): Observable<CaseHistory> {
     let caseView: CaseView = route.parent.data.case;
+    let jurisdictionId = caseView.case_type.jurisdiction.id;
+    let caseTypeId = caseView.case_type.id;
     let caseId = caseView.case_id;
     let triggerId = route.paramMap.get(CaseHistoryResolver.PARAM_EVENT_ID);
-    return this.getCaseHistoryView(caseId, triggerId);
+    return this.getCaseHistoryView(jurisdictionId, caseTypeId, caseId, triggerId);
   }
 
-  private getCaseHistoryView(cid, eid): Observable<CaseHistory> {
+  private getCaseHistoryView(jid, ctid, cid, eid): Observable<CaseHistory> {
     return this.caseHistoryService
-      .get(cid, eid)
+      .get(jid, ctid, cid, eid)
       .catch((error: Response | any) => {
         console.error(error);
         if (error.status !== 401 && error.status !== 403) {

--- a/src/app/workbasket/workbasket-input-filter.service.spec.ts
+++ b/src/app/workbasket/workbasket-input-filter.service.spec.ts
@@ -65,16 +65,12 @@ describe('DefinitionsService', () => {
         },
         {
           label: 'Field 2',
-          field: {
-            id: 'field2', field_type: { id: 'Text', type: 'Text' }, value: 'Some Value', label: 'Field 2'
-          },
+          field: { id: 'field2', field_type: { id: 'Text', type: 'Text' }, value: 'Some Value', label: 'Field 2' },
           order: 2
         },
         {
           label: 'Field 3',
-          field: {
-            id: 'field3', field_type: { id: 'Text', type: 'Text' }, value: '', label: 'Field 3'
-          },
+          field: { id: 'field3', field_type: { id: 'Text', type: 'Text' }, value: '', label: 'Field 3' },
           order: 3
         }
       ];


### PR DESCRIPTION
corresponding data-store PR has been merged but the build is not passing due to flaky tests. if this original PR is built in Master before data-store is built, case event history end point will be broken. Am reverting this PR as it is blocking all other merges to master