### PR TITLE
Revert "[Security] Bump handlebars from 4.0.12 to 4.1.0"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,12 @@ ARG base=hmcts.azurecr.io/hmcts/base/node/stretch-slim-lts-8:latest
 # Both frontend and backend codebases are bundled from their
 # .ts source into .js, producing self-sufficient scripts.
 FROM ${base} AS build
-USER root
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     bzip2=1.0.6-8.1 \
     patch=2.7.5-1+deb9u1 \
     libfontconfig1=2.11.0-6.7+b1 \
     && rm -rf /var/lib/apt/lists/*
-USER hmcts
 COPY package.json yarn.lock .snyk ./
 RUN yarn install
 COPY . .
@@ -20,4 +18,5 @@ RUN yarn build:ssr
 # ---- Runtime image ----
 FROM ${base} AS runtime
 COPY --from=build ${WORKDIR}/dist/ ./
+USER hmcts
 CMD node ./server.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -4280,8 +4280,8 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"
 
 handlebars@^4.0.1, handlebars@^4.0.11:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.0.tgz#0d6a6f34ff1f63cecec8423aa4169827bf787c3a"
+  version "4.0.12"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.12.tgz#2c15c8a96d46da5e266700518ba8cb8d919d5bc5"
   dependencies:
     async "^2.5.0"
     optimist "^0.6.1"


### PR DESCRIPTION
This reverts commit dfb812760f89df4cfcb98d16a4652aab6af7cbac.

Seems to be messing with our smake tests









**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```