### PR TITLE
replaced no longer working pipeline method afterCheckout

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -50,7 +50,7 @@ withPipeline("angular", product, component) {
     overrideVaultEnvironments(vaultOverrides)
     loadVaultSecrets(secrets)
 
-    afterCheckout {
+    after('checkout') {
         sh "yarn cache clean"
     }
 

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -50,7 +50,7 @@ withNightlyPipeline(type, product, app) {
     env.CCD_CASEWORKER_AUTOTEST_FE_EMAIL = params.AUTOTEST_EMAIL_PARAM
     env.CCD_CASEWORKER_AUTOTEST_FE_PASSWORD = params.AUTOTEST_PASSWORD_PARAM
 
-    afterCheckout {
+    after('checkout') {
         sh "yarn cache clean"
     }
 

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -36,7 +36,7 @@ withParameterizedPipeline('angular', 'ccd', 'case-management-web', params.ENVIRO
 
     enableSlackNotifications('#ccd-param-builds')
 
-    afterCheckout {
+    after('checkout') {
         sh "yarn cache clean"
     }
 


### PR DESCRIPTION
Cloud Native changed the afterCheckout method to after('checkout'). Updating the pipelines accordingly

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
