### PR TITLE
RDM-3611-increment-toolkit-version

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@angular/platform-server": "~7.0.3",
     "@angular/router": "~7.0.3",
     "@angular/upgrade": "~7.0.3",
-    "@hmcts/ccd-case-ui-toolkit": "2.47.0",
+    "@hmcts/ccd-case-ui-toolkit": "2.48.0",
     "@hmcts/ccpay-web-component": "~1.8.1",
     "@nguniversal/express-engine": "^6.0.0",
     "@nguniversal/module-map-ngfactory-loader": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -310,9 +310,10 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@hmcts/ccd-case-ui-toolkit@2.47.0":
-  version "2.47.0"
-  resolved "https://registry.yarnpkg.com/@hmcts/ccd-case-ui-toolkit/-/ccd-case-ui-toolkit-2.47.0.tgz#13704680edb2a17b8570c9e548052c6546aee968"
+"@hmcts/ccd-case-ui-toolkit@2.48.0":
+  version "2.48.0"
+  resolved "https://registry.yarnpkg.com/@hmcts/ccd-case-ui-toolkit/-/ccd-case-ui-toolkit-2.48.0.tgz#28f4f128736428cf72c8fd9f7b1f1c72839bea9e"
+  integrity sha512-5uC1vRkBOBU9EvEyXveyoRKM5Wn1fdCAmEmmJIcffXlDB7R/zG6oLXr58AK04JX1iNNxjXGFoAsHJPzwWEwwWA==
   dependencies:
     "@angular/cli" "^6.0.8"
     "@angular/compiler-cli" "~7.0.3"


### PR DESCRIPTION
### JIRA link (if applicable) ###

RDM-3611

### Change description ###

The change is to make use of a new version of toolkit which contains a fix so values injected into readonly fields via a callback now persist. 
