### PR TITLE
RDM-876-2: Hide Print button when not configured

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@angular/platform-server": "~7.0.3",
     "@angular/router": "~7.0.3",
     "@angular/upgrade": "~7.0.3",
-    "@hmcts/ccd-case-ui-toolkit": "2.48.0",
+    "@hmcts/ccd-case-ui-toolkit": "2.49.2",
     "@hmcts/ccpay-web-component": "~1.8.1",
     "@nguniversal/express-engine": "^6.0.0",
     "@nguniversal/module-map-ngfactory-loader": "^6.0.0",

--- a/test/features/caseView.feature
+++ b/test/features/caseView.feature
@@ -3,13 +3,15 @@ Feature: Set of scenarios testing case view functionality
 
   Background:
     Given I have logged in
-    And a case containing Tabs functionality exists
-    And I create the case
 
   Scenario: case reference visible on case view
+    Given a case containing Tabs functionality exists
+    And I create the case
     Then the case reference will be visible and formatted well
 
   Scenario: tabs visible on case view
+    Given a case containing Tabs functionality exists
+    And I create the case
     Then the success case created bar will be visible
     And the following tabs will be visible:
       | History             |
@@ -21,11 +23,22 @@ Feature: Set of scenarios testing case view functionality
       | Conditional Tab 3   |
 
   Scenario: tab fields visible on case view
+    Given a case containing Tabs functionality exists
+    And I create the case
     When I navigate to tab 'Tab2'
     Then the following fields will be visible:
       | Text Field 2        |
       | Text Field 3        |
       | Text Field 4        |
 
-  Scenario: print button visible on case view
-   Then the print button will be visible
+  @functional
+  Scenario: print button visible on case view when configured
+    Given a case type with the print button configured exist
+    And I create the case
+    Then the print button will be visible
+
+  @functional
+  Scenario: print button not visible on case view by default
+    Given a case with the print button not configured exists
+    And I create the case
+    Then the print button will not be visible

--- a/test/pageObjects/caseDetailsPage.js
+++ b/test/pageObjects/caseDetailsPage.js
@@ -64,8 +64,12 @@ class CaseDetailsPage extends BasePage {
    */
 
   async isPrintButtonReady() {
-    return await $(this._printButton).isDisplayed()
+    try {
+      return await $(this._printButton).isDisplayed()
         && await $(this._printButton).isEnabled();
+    } catch (e) {
+      return false;
+    }
   }
 
   /**

--- a/test/stepDefinitions/caseDetailsSteps.js
+++ b/test/stepDefinitions/caseDetailsSteps.js
@@ -60,6 +60,10 @@ defineSupportCode(function ({ Given, When, Then, Before, After }) {
     expect(await caseDetailsPage.isPrintButtonReady()).to.be.true;
   });
 
+  Then(/^the print button will not be visible$/, async function () {
+    expect(await caseDetailsPage.isPrintButtonReady()).to.be.false;
+  });
+
   Then(/^the case reference will be visible and formatted well$/, async function () {
     expect(await caseDetailsPage.isCaseReferenceVisible()).to.be.true;
     expect(await caseDetailsPage.isCaseReferenceOfCorrectFormat()).to.be.true;

--- a/test/stepDefinitions/definitionFileSteps.js
+++ b/test/stepDefinitions/definitionFileSteps.js
@@ -9,10 +9,18 @@ defineSupportCode(function ({ Given, When, Then, Before, After }) {
     Data.optionalFields = [{fieldType: 'text', fieldId: 'TextFieldFName'}];
   });
 
-  Given(/^a case type containing every field type exists$/, function() {
+  async function populateCaseFields(){
     Data.jurisdiction = 'Auto Test 1';
     Data.caseType = 'All Field Data Types';
     Data.optionalFields = [{fieldType: 'text', fieldId: 'TextField'}];
+  }
+
+  Given(/^a case type containing every field type exists$/, async function() {
+    await populateCaseFields();
+  });
+
+  Given(/^a case type with the print button configured exist$/, async function() {
+    await populateCaseFields();
   });
 
   Given(/^a case type containing a collection of complex types exists$/, function() {
@@ -36,11 +44,20 @@ defineSupportCode(function ({ Given, When, Then, Before, After }) {
                             {fieldType: 'text', fieldId: 'MyCompany_0_BusinessAddress_Country'}];
     });
 
-  Given(/^a case with Case Progression functionality exists$/, function() {
+  async function populateCaseProgressionType(){
     Data.caseType = 'Case Progression';
+    Data.optionalFields = [];
     Data.mandatoryFields = [{fieldType: 'text', fieldId: 'TextField0'},
-                            {fieldType: 'text', fieldId: 'TextField1'},
-                            {fieldType: 'text', fieldId: 'TextField2'}];
+      {fieldType: 'text', fieldId: 'TextField1'},
+      {fieldType: 'text', fieldId: 'TextField2'}];
+  }
+
+  Given(/^a case with Case Progression functionality exists$/, async function() {
+    await populateCaseProgressionType();
+  });
+
+  Given(/^a case with the print button not configured exists$/, async function() {
+    await populateCaseProgressionType();
   });
 
   Given(/^a case containing Tabs functionality exists$/, function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -309,11 +309,11 @@
     esutils "^2.0.2"
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
-    
-"@hmcts/ccd-case-ui-toolkit@2.48.0":
-  version "2.48.0"
-  resolved "https://registry.yarnpkg.com/@hmcts/ccd-case-ui-toolkit/-/ccd-case-ui-toolkit-2.48.0.tgz#28f4f128736428cf72c8fd9f7b1f1c72839bea9e"
-  integrity sha512-5uC1vRkBOBU9EvEyXveyoRKM5Wn1fdCAmEmmJIcffXlDB7R/zG6oLXr58AK04JX1iNNxjXGFoAsHJPzwWEwwWA==
+
+"@hmcts/ccd-case-ui-toolkit@2.49.2":
+  version "2.49.2"
+  resolved "https://registry.yarnpkg.com/@hmcts/ccd-case-ui-toolkit/-/ccd-case-ui-toolkit-2.49.2.tgz#de46d2e825dec40369e57e9d4765be11d2a56680"
+  integrity sha512-hHUDERhfaOxlaX2VZHok2HPQYxifMWm1o/JA2To0n/rKRwT1+Y5gltRB+CVwXA6OVGTpDAu0VZ69YqiUmcPBOg==
   dependencies:
     "@angular/cli" "^6.0.8"
     "@angular/compiler-cli" "~7.0.3"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-876

### Change description ###
As a court staff I do not want to see the Print button if the print callback url is not configured so that I do not have any confusion.

ccd-case-ui-toolkit PR (related):
https://github.com/hmcts/ccd-case-ui-toolkit/pull/270

ccd-data-store-api PR (related):
https://github.com/hmcts/ccd-data-store-api/pull/401

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
