### PR TITLE
fix flaky func tests on login page:

### DIFF
--- a/test/pageObjects/loginPage.js
+++ b/test/pageObjects/loginPage.js
@@ -20,7 +20,7 @@ class LoginPage extends BasePage {
   static async open(){
 
       //open browser and navigate to url
-      await browser.get(process.env.TEST_URL || 'http://localhost:3451',50000);
+      await browser.driver.get(process.env.TEST_URL || 'http://localhost:3451',50000);
 
       //wait for browser url to be correct
       let EC = protractor.ExpectedConditions;

--- a/test/pageObjects/loginPage.js
+++ b/test/pageObjects/loginPage.js
@@ -24,10 +24,10 @@ class LoginPage extends BasePage {
 
       //wait for browser url to be correct
       let EC = protractor.ExpectedConditions;
-      let currentURL = await browser.getCurrentUrl();
+      let currentURL = await browser.driver.getCurrentUrl();
       let errorMessage = `Failed to load page, Expected URL fragment: ${selfUrlPath} | Actual URL: ${currentURL}`;
 
-      await browser.wait(EC.urlContains(selfUrlPath),30000)
+      await browser.driver.wait(EC.urlContains(selfUrlPath),30000)
         .catch(err => console.log(errorMessage));
 
       //return new instance of the login page


### PR DESCRIPTION
It looks like we have flaky random functional tests failing because of the following error:
```UnhandledPromiseRejectionWarning: Error: Error while waiting for Protractor to sync with the page: "both angularJS testability```
That is always happening on the login page step. 
Found a potential solution on stackoverflow:
https://stackoverflow.com/questions/23634648/getting-error-error-while-waiting-for-protractor-to-sync-with-the-page/23881721
