### PR TITLE
RDM-8348: bump up media viewer version to 1.3.1 in CCD UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@angular/upgrade": "~7.0.3",
     "@hmcts/ccd-case-ui-toolkit": "2.64.4-EUI",
     "@hmcts/ccpay-web-component": "3.0.3",
-    "@hmcts/media-viewer": "1.1.9",
+    "@hmcts/media-viewer": "1.3.1",
     "@hmcts/nodejs-healthcheck": "^1.5.1",
     "@nguniversal/express-engine": "^6.0.0",
     "@nguniversal/module-map-ngfactory-loader": "^6.0.0",

--- a/src/app/mv-wrapper/media-viewer-wrapper.component.html
+++ b/src/app/mv-wrapper/media-viewer-wrapper.component.html
@@ -3,6 +3,5 @@
                  [downloadFileName]="mediaFilename"
                  [showToolbar]="true"
                  [contentType]="mediaContentType"
-                 [showCommentSummary]="true"
                  [enableAnnotations]="true">
 </mv-media-viewer>

--- a/yarn.lock
+++ b/yarn.lock
@@ -370,13 +370,15 @@
   resolved "https://registry.yarnpkg.com/@hmcts/frontend/-/frontend-0.0.34-alpha.tgz#0d39b6d06c632ccb7c578fc91e3311306da9db0d"
   integrity sha512-+q3IB4L3UHsD5cs/11PDWEftDAmDV6eYkxm9eoNtXAfea93VhXNFA9ZEIV+TM7v/9xaAIkmDj9C4kCSUb1Hl3g==
 
-"@hmcts/media-viewer@1.1.9":
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/@hmcts/media-viewer/-/media-viewer-1.1.9.tgz#86c6d2ebec3dd15807d386182bd15f6b390b7c22"
-  integrity sha512-2SnJpSvXI9wvKhjRlYm/S2P5mz/0JTp9NNkA4qpu3FNZF0bEn2yRsaF/LixoAi05JV8GFTpL3vJLOEiClaJf8g==
+"@hmcts/media-viewer@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@hmcts/media-viewer/-/media-viewer-1.3.1.tgz#a5975df44fbe77018afb9c709cde4eb92d185973"
+  integrity sha512-pFE8nrp5BXi008LerP9LbO2RUTPDbqD7b7yda97tqLg/NU2qfZPVrgksqytTJNPpJt1AAyGQtz9MjfAYmVKF3Q==
   dependencies:
     "@hmcts/frontend" "^0.0.34-alpha"
     govuk-frontend "^2.11.0"
+    hammerjs "^2.0.8"
+    mutable-div "0.0.11"
     pdfjs-dist "2.0.943"
     tslib "^1.9.0"
     uuid "^3.3.2"
@@ -5576,6 +5578,11 @@ gulplog@^1.0.0:
   dependencies:
     glogg "^1.0.0"
 
+hammerjs@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
+  integrity sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=
+
 handle-thing@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"
@@ -8372,6 +8379,13 @@ multiple-cucumber-html-reporter@^1.11.7:
     moment "^2.24.0"
     open "^7.0.2"
     uuid "^3.4.0"
+
+mutable-div@0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/mutable-div/-/mutable-div-0.0.11.tgz#b807c826ed16ca96fcb51e34dc0303ab901464b0"
+  integrity sha512-R6r3UAdPX2oHeWKLPX4BpnHa9Un/NdjovHyOk/TbDX0gCx5yxVftGewX6oP8yYxYbo0VsV9jU9PZtOzrJ9EKvQ==
+  dependencies:
+    tslib "^1.9.0"
 
 mute-stream@0.0.7:
   version "0.0.7"


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-8348

### Change description ###

Change media-viewer version fron 1.1.9 to 1.3.1

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
