### PR TITLE
IE11 fix - lowering class-transformer to ^0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "chai-like": "^0.2.14",
-    "class-transformer": "^0.3.1",
+    "class-transformer": "^0.2.3",
     "core-js": "^2.6.9",
     "cucumber": "^5.0.0",
     "cucumber-html-reporter": "^4.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2790,10 +2790,10 @@ circular-json@^0.5.1, circular-json@^0.5.5:
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.5.9.tgz#932763ae88f4f7dead7a0d09c8a51a4743a53b1d"
   integrity sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ==
 
-class-transformer@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.3.1.tgz#ee681a5439ff2230fc57f5056412d3befa70d597"
-  integrity sha512-cKFwohpJbuMovS8xVLmn8N2AUbAuc8pVo4zEfsUVo8qgECOogns1WVk/FkOZoxhOPTyTYFckuoH+13FO+MQ8GA==
+class-transformer@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.2.3.tgz#598c92ca71dcca73f91ccb875d74a3847ccfa32d"
+  integrity sha512-qsP+0xoavpOlJHuYsQJsN58HXSl8Jvveo+T37rEvCEeRfMWoytAyR0Ua/YsFgpM6AZYZ/og2PJwArwzJl1aXtQ==
 
 class-utils@^0.3.5:
   version "0.3.6"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-9707


### Change description ###
Resolve IE-11 compatibility issue by lowering class-transformer to ^0.2.3.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```
