### PR TITLE
CCD-1948, CCD-1949 & CCD-1950

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "glob-parent": "^5.1.2",
     "normalize-url": "^6.0.1",
     "trim-newlines": "^4.0.1",
-    "tar": "^6.1.2"
+    "tar": "^6.1.9"
   },
   "snyk": true
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13715,10 +13715,10 @@ tar-stream@^2.0.1, tar-stream@^2.1.0, tar-stream@^2.2.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^2.0.0, tar@^4.4.6, tar@^6.0.2, tar@^6.1.2:
-  version "6.1.6"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.6.tgz#c23d797b0a1efe5d479b1490805c5443f3560c5d"
-  integrity sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==
+tar@^2.0.0, tar@^4.4.6, tar@^6.0.2, tar@^6.1.2, tar@^6.1.9:
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"


### PR DESCRIPTION
### [CCD-1948](https://tools.hmcts.net/jira/browse/CCD-1948) ###
### [CCD-1949](https://tools.hmcts.net/jira/browse/CCD-1949) ###
### [CCD-1950](https://tools.hmcts.net/jira/browse/CCD-1950) ###


### Change description ###
Bumped transient dependency tar to v6.1.9 to resolve the following CVE's:
[CVE-2021-37701](https://nvd.nist.gov/vuln/detail/CVE-2021-37701)
[CVE-2021-37712](https://nvd.nist.gov/vuln/detail/CVE-2021-37712)
[CVE-2021-37713](https://nvd.nist.gov/vuln/detail/CVE-2021-37713)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
